### PR TITLE
More precise error message when login successfull

### DIFF
--- a/custom_components/cozytouch/config_flow.py
+++ b/custom_components/cozytouch/config_flow.py
@@ -49,7 +49,7 @@ class CozytouchFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors = {"base": "login_inccorect"}
                 _LOGGER.error("Error: %s", e)
             except CozytouchException as e:
-                errors = {"base": "login_inccorect"}
+                errors = {"base": "parsing"}
                 _LOGGER.error("Error: %s", e)
 
             if "base" not in errors:

--- a/custom_components/cozytouch/translations/en.json
+++ b/custom_components/cozytouch/translations/en.json
@@ -13,6 +13,7 @@
 		},
 		"error": {
 			"login_inccorect": "User or password inccorect",
+			"parsing": "Server response non parsable",
 			"unknown": "Unknown error occurred"
 		}
 	}

--- a/custom_components/cozytouch/translations/fr.json
+++ b/custom_components/cozytouch/translations/fr.json
@@ -14,6 +14,7 @@
 		},
 		"error": {
 			"login_inccorect": "Utilisateur ou mot de passe incorrect.",
+			"parsing": "Interpretation de la réponse du serveur impossible",
 			"unknown": "Erreur inconnue."
 		}
 	}


### PR DESCRIPTION
This should print a more informative message for case similar to https://github.com/Cyr-ius/hass-cozytouch/issues/8